### PR TITLE
Update testlib.py - add initial wait sleep

### DIFF
--- a/ovirtlago/testlib.py
+++ b/ovirtlago/testlib.py
@@ -209,7 +209,7 @@ def _instance_of_any(obj, cls_list):
     return any(True for cls in cls_list if isinstance(obj, cls))
 
 
-def assert_equals_within(func, value, timeout, allowed_exceptions=None):
+def assert_equals_within(func, value, timeout, allowed_exceptions=None, initial_wait=10):
     allowed_exceptions = allowed_exceptions or []
     with utils.EggTimer(timeout) as timer:
         while not timer.elapsed():
@@ -219,12 +219,17 @@ def assert_equals_within(func, value, timeout, allowed_exceptions=None):
                     return
             except Exception as exc:
                 if _instance_of_any(exc, allowed_exceptions):
+                    time.sleep(3)
                     continue
 
                 LOGGER.exception("Unhandled exception in %s", func)
                 raise
 
-            time.sleep(3)
+            if initial_wait == 0:
+                time.sleep(3)
+            else:
+                sleep(initial_wait)
+                initial_wait = 0
     try:
         raise AssertionError(
             '%s != %s after %s seconds' % (res, value, timeout)


### PR DESCRIPTION
1. Add an initial wait. After the first cycle, wait 'initial_wait' seconds (by default 10) before another query. Reduces the load on the Engine, especially when many tasks are involved in parallel.
2. Sleep if an allowed exception was caught.